### PR TITLE
Changed API targetframework to netstandard2.0

### DIFF
--- a/BinanceExchange.API/BinanceExchange.API.csproj
+++ b/BinanceExchange.API/BinanceExchange.API.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>3.0.1</Version>
     <Description>The Binance CryptoCurrency exchange C# wrapper of the API. It is built in dotnet core, supports all REST and WebSocket endpoints, has full logging capabilities, a built in Cache for selected endpoints, a Rate limiter and more. Enjoy Binance API data, fast and reliably.</Description>
     <PackageId>BinanceDotNet</PackageId>
@@ -24,9 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <PackageReference Include="System.Net.Http.Formatting.Extension" Version="5.2.3" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc5" />
     <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
   </ItemGroup>
 </Project>

--- a/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
+++ b/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
@@ -147,8 +147,10 @@ namespace BinanceExchange.API.Websockets
                     }
                 };
             };
-            ActiveWebSockets.TryAdd(websocket.Id, websocket);
-            AllSockets.Add(websocket);
+            if (!ActiveWebSockets.ContainsKey(websocket.Id))
+                ActiveWebSockets.Add(websocket.Id, websocket);
+
+			AllSockets.Add(websocket);
             websocket.SslConfiguration.EnabledSslProtocols = SupportedProtocols;
             websocket.Connect();
 
@@ -181,7 +183,8 @@ namespace BinanceExchange.API.Websockets
                     }
                 };
             };
-            ActiveWebSockets.TryAdd(websocket.Id, websocket);
+            if (!ActiveWebSockets.ContainsKey(websocket.Id))
+                ActiveWebSockets.Add(websocket.Id, websocket);
             AllSockets.Add(websocket);
             websocket.SslConfiguration.EnabledSslProtocols = SupportedProtocols;
             websocket.Connect();


### PR DESCRIPTION
Changed the TargetFramework for the Api project (the one that turns into the NuGet package) to netstandard2.0 to allow the package to be used in projects targetting the full framework.

The Dictionary change was necessary because the TryAdd method is apparently only available to the netcoreapp2.0 targetframework, but that change was very minor anyway.

Also removed some PackageReferences that have apparently become obsolete and updated the NLog one to the latest version (though I'd advise to use the Microsoft logging abstractions instead, but that may be something for a future update ;))