### PR TITLE
BDN10 - Convert properties to nullables in requests

### DIFF
--- a/BinanceExchange.API/APIProcessor.cs
+++ b/BinanceExchange.API/APIProcessor.cs
@@ -44,12 +44,26 @@ namespace BinanceExchange.API
             _cacheTime = time;
         }
 
-        private async Task<T> HandleResponse<T>(HttpResponseMessage message, string fullCacheKey) where T : class
+        private async Task<T> HandleResponse<T>(HttpResponseMessage message, string requestMessage, string fullCacheKey) where T : class
         {
             if (message.IsSuccessStatusCode)
             {
                 var messageJson = await message.Content.ReadAsStringAsync();
-                var messageObject = JsonConvert.DeserializeObject<T>(messageJson);
+                T messageObject = null;
+                try
+                {
+                    messageObject = JsonConvert.DeserializeObject<T>(messageJson);
+                }
+                catch (Exception ex)
+                {
+                    string deserializeErrorMessage = $"Unable to deserialize message from: {requestMessage}. Exception: {ex.Message}";
+                    _logger.Error(deserializeErrorMessage);
+                    throw new BinanceException(deserializeErrorMessage, new BinanceError()
+                    {
+                        RequestMessage = requestMessage,
+                        Message = ex.Message
+                    });
+                }
                 _logger.Debug($"Successful Message Response={messageJson}");
 
                 if (messageObject == null)
@@ -66,8 +80,10 @@ namespace BinanceExchange.API
             var errorJson = await message.Content.ReadAsStringAsync();
             var errorObject = JsonConvert.DeserializeObject<BinanceError>(errorJson);
             if (errorObject == null) throw new BinanceException("Unexpected Error whilst handling the response", null);
-            _logger.Error($"Error Message Recevied", errorObject);
-            throw CreateBinanceException(message.StatusCode, errorObject);
+            errorObject.RequestMessage = requestMessage;
+            var exception = CreateBinanceException(message.StatusCode, errorObject);
+            _logger.Error(exception, $"Error Message Received:");
+            throw exception;
         }
 
         private BinanceException CreateBinanceException(HttpStatusCode statusCode, BinanceError errorObject)
@@ -113,8 +129,7 @@ namespace BinanceExchange.API
             var fullKey = $"{typeof(T).Name}-{endpoint.Uri.AbsoluteUri}";
             if (_cacheEnabled && endpoint.UseCache)
             {
-                T item;
-                if (CheckAndRetrieveCachedItem<T>(fullKey, out item))
+                if (CheckAndRetrieveCachedItem<T>(fullKey, out var item))
                 {
                     return item;
                 }
@@ -131,7 +146,7 @@ namespace BinanceExchange.API
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            return await HandleResponse<T>(message, fullKey);
+            return await HandleResponse<T>(message, endpoint.ToString(), fullKey);
         }
 
         /// <summary>
@@ -164,7 +179,7 @@ namespace BinanceExchange.API
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            return await HandleResponse<T>(message, fullKey);
+            return await HandleResponse<T>(message, endpoint.ToString(), fullKey);
         }
 
         /// <summary>
@@ -198,7 +213,7 @@ namespace BinanceExchange.API
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            return await HandleResponse<T>(message, fullKey);
+            return await HandleResponse<T>(message, endpoint.ToString(), fullKey);
         }
 
         /// <summary>
@@ -229,7 +244,7 @@ namespace BinanceExchange.API
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            return await HandleResponse<T>(message, fullKey);
+            return await HandleResponse<T>(message, endpoint.ToString(), fullKey);
         }
     }
 }

--- a/BinanceExchange.API/BinanceEndpointData.cs
+++ b/BinanceExchange.API/BinanceEndpointData.cs
@@ -15,5 +15,10 @@ namespace BinanceExchange.API
             SecurityType = securityType;
             UseCache = useCache;
         }
+
+        public override string ToString()
+        {
+            return Uri.AbsoluteUri;
+        }
     }
 }

--- a/BinanceExchange.API/BinanceExchange.API.csproj
+++ b/BinanceExchange.API/BinanceExchange.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <Version>3.1.0-alpha1</Version>
+    <Version>3.1.0</Version>
     <Description>The Binance CryptoCurrency exchange C# wrapper of the API. It is built in dotnet core, supports all REST and WebSocket endpoints, has full logging capabilities, a built in Cache for selected endpoints, a Rate limiter and more. Enjoy Binance API data, fast and reliably.</Description>
     <PackageId>BinanceDotNet</PackageId>
     <Authors>Jon Evans</Authors>
@@ -13,7 +13,7 @@
     <PackageLicenseUrl>https://github.com/glitch100/BinanceDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/glitch100/BinanceDotNet</RepositoryUrl>
     <PackageIconUrl>https://i.imgur.com/x2YPVe6.png</PackageIconUrl>
-    <PackageReleaseNotes>Making properties nullable so request query strings are accurate</PackageReleaseNotes>
+    <PackageReleaseNotes>Making properties nullable so request query strings are accurate, added error catching in deserialization, and additional logs</PackageReleaseNotes>
     <AssemblyVersion>3.1.0.0</AssemblyVersion>
     <FileVersion>3.1.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/BinanceExchange.API/BinanceExchange.API.csproj
+++ b/BinanceExchange.API/BinanceExchange.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <Version>3.0.1</Version>
+    <Version>3.1.0-alpha1</Version>
     <Description>The Binance CryptoCurrency exchange C# wrapper of the API. It is built in dotnet core, supports all REST and WebSocket endpoints, has full logging capabilities, a built in Cache for selected endpoints, a Rate limiter and more. Enjoy Binance API data, fast and reliably.</Description>
     <PackageId>BinanceDotNet</PackageId>
     <Authors>Jon Evans</Authors>
@@ -13,9 +13,9 @@
     <PackageLicenseUrl>https://github.com/glitch100/BinanceDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/glitch100/BinanceDotNet</RepositoryUrl>
     <PackageIconUrl>https://i.imgur.com/x2YPVe6.png</PackageIconUrl>
-    <PackageReleaseNotes>Bug around OrderStatus enum</PackageReleaseNotes>
-    <AssemblyVersion>3.0.1.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <PackageReleaseNotes>Making properties nullable so request query strings are accurate</PackageReleaseNotes>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/BinanceExchange.API/Endpoints.cs
+++ b/BinanceExchange.API/Endpoints.cs
@@ -212,7 +212,8 @@ namespace BinanceExchange.API
 
             return String.Join("&", obj.Children()
                 .Cast<JProperty>()
-                .Select(j => j.Name + "=" + HttpUtility.UrlEncode(j.Value.ToString())));
+                .Where(j => j.Value != null)
+                .Select(j => j.Name + "=" + System.Net.WebUtility.UrlEncode(j.Value.ToString())));
         }
     }
 }

--- a/BinanceExchange.API/Models/Request/AllOrdersRequest.cs
+++ b/BinanceExchange.API/Models/Request/AllOrdersRequest.cs
@@ -12,9 +12,9 @@ namespace BinanceExchange.API.Models.Request
         public string Symbol { get; set; }
 
         [DataMember(Order = 2)]
-        public long OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         [DataMember(Order = 3)]
-        public int Limit { get; set; }
+        public int? Limit { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Request/AllTradesRequest.cs
+++ b/BinanceExchange.API/Models/Request/AllTradesRequest.cs
@@ -12,9 +12,9 @@ namespace BinanceExchange.API.Models.Request
         public string Symbol { get; set; }
 
         [DataMember(Order = 2)]
-        public long FromId { get; set; }
+        public long? FromId { get; set; }
 
         [DataMember(Order = 3)]
-        public int Limit { get; set; }
+        public int? Limit { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Request/CancelOrderRequest.cs
+++ b/BinanceExchange.API/Models/Request/CancelOrderRequest.cs
@@ -13,13 +13,13 @@ namespace BinanceExchange.API.Models.Request
         public string Symbol { get; set; }
 
         [DataMember(Order = 2)]
-        public long OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         [DataMember(Order = 3)]
         [JsonProperty(PropertyName = "origClientOrderId")]
-        public long OriginalClientOrderId { get; set; }
+        public long? OriginalClientOrderId { get; set; }
 
         [DataMember(Order = 4)]
-        public long NewClientOrderId { get; set; }
+        public long? NewClientOrderId { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Request/CreateOrderRequest.cs
+++ b/BinanceExchange.API/Models/Request/CreateOrderRequest.cs
@@ -36,10 +36,10 @@ namespace BinanceExchange.API.Models.Request
         public string NewClientOrderId { get; set; }
 
         [DataMember(Order = 8)]
-        public decimal StopPrice { get; set; }
+        public decimal? StopPrice { get; set; }
 
         [DataMember(Order = 9)]
         [JsonProperty("icebergQty")]
-        public decimal IcebergQuantity { get; set; }
+        public decimal? IcebergQuantity { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Request/FundHistoryRequest.cs
+++ b/BinanceExchange.API/Models/Request/FundHistoryRequest.cs
@@ -13,14 +13,14 @@ namespace BinanceExchange.API.Models.Request
         public string Asset { get; set; }
 
         [DataMember(Order = 2)]
-        public DepositHistoryStatus Status { get; set; }
+        public DepositHistoryStatus? Status { get; set; }
 
         [DataMember(Order = 3)]
         [JsonConverter(typeof(EpochTimeConverter))]
-        public DateTime StartTime { get; set; }
+        public DateTime? StartTime { get; set; }
 
         [DataMember(Order = 4)]
         [JsonConverter(typeof(EpochTimeConverter))]
-        public DateTime EndTime { get; set; }
+        public DateTime? EndTime { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Request/QueryOrderRequest.cs
+++ b/BinanceExchange.API/Models/Request/QueryOrderRequest.cs
@@ -13,7 +13,7 @@ namespace BinanceExchange.API.Models.Request
         public string Symbol { get; set; }
 
         [DataMember(Order = 2)]
-        public long OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         [DataMember(Order = 3)]
         [JsonProperty(PropertyName = "origClientOrderId")]

--- a/BinanceExchange.API/Models/Response/Error/BinanceError.cs
+++ b/BinanceExchange.API/Models/Response/Error/BinanceError.cs
@@ -9,6 +9,8 @@ namespace BinanceExchange.API.Models.Response.Error
         [JsonProperty(PropertyName = "msg")]
         public string Message { get; set; }
 
+        public string RequestMessage { get; set; }
+
         public override string ToString()
         {
             return $"{Code}: {Message}";

--- a/BinanceExchange.API/Models/Response/OrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/OrderResponse.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using BinanceExchange.API.Converter;
 using BinanceExchange.API.Enums;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace BinanceExchange.API.Models.Response
 {
@@ -29,6 +30,7 @@ namespace BinanceExchange.API.Models.Response
         [JsonProperty(PropertyName = "executedQty")]
         public decimal ExecutedQuantity { get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
         [DataMember(Order = 6)]
         public OrderStatus Status { get; set; }
 

--- a/BinanceExchange.API/RequestClient.cs
+++ b/BinanceExchange.API/RequestClient.cs
@@ -118,6 +118,7 @@ namespace BinanceExchange.API
         {
             _logger.Debug($"Creating a SIGNED GET Request to {endpoint.AbsoluteUri}");
             var uri = CreateValidUri(endpoint, secretKey, signatureRawData, receiveWindow);
+            _logger.Debug($"Concat URL for request: {uri.AbsoluteUri}");
             return await CreateRequest(uri, HttpVerb.GET);
         }
 

--- a/BinanceExchange.Console/ExampleProgram.cs
+++ b/BinanceExchange.Console/ExampleProgram.cs
@@ -77,7 +77,8 @@ namespace BinanceExchange.Console
                     Symbol = TradingPairSymbols.BTCPairs.ETH_BTC,
                     Limit = 5,
                 };
-                var allOrders = await client.GetAllOrders(allOrdersRequest);                // Get All Orders
+                // Get All Orders
+                var allOrders = await client.GetAllOrders(allOrdersRequest);                
 
                 // Get the order book, and use the cache
                 var orderBook = await client.GetOrderBook("ETHBTC", true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # BinanceDotNet Changelog
 
-**Release Date: To be determined**
+**Release Date: 01/16/2018**
 ## 3.1.0
 - Made properties in requests nullable to prevent malformed requests when params not provided
+- Additional logging
+- Fix for `OrderStatus` issue
+- `catch` for deserializing response
 
 **Release Date: 01/11/2018**
 ## 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # BinanceDotNet Changelog
 
+**Release Date: To be determined**
+## 3.1.0
+- Made properties in requests nullable to prevent malformed requests when params not provided
+
 **Release Date: 01/11/2018**
 ## 3.0.1
 - Fixed `OrderStatus` enum bug. Issue #7

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Feel free to raise issues and Pull Request to help improve the library. If you f
 - [REST API Calls](/docs/REST-API.md)
 - [WebSocket API Calls](/docs/WEBSOCKET-API.md)
 
+## Donations and Contribution
+Upkeep of this API takes a lot of time from answering issues and PR's on the Repository, as well as tweets and direct emails.
+You can donate cryptocurrency of any amount to the following wallets:
+
+```
+ETH: 0xd5775e2dee4b9fa9a3be5222970c04ac574e8412
+TRX: 0xd5775e2dee4b9fa9a3be5222970c04ac574e8412
+```
+_Want to send something else? Just tweet me! @Glitch100_
+
+Or you can help maintain the repository! Donations of time are welcome, just hit me up and we can work on it. From answering issues, to contributing code anyone can assist.
+
+
 ## Features
 - Simple, Configurable, Extendable
 - Rate limiting, with 10 requests in 10 seconds _(disabled by default)_


### PR DESCRIPTION
## Overview
This branch changes 
This resolves issue #10  

## Testing
### Pre-steps
To install please use the following NuGet. Note that it is a pre-release.

[https://www.nuget.org/packages/BinanceDotNet/3.1.0-alpha2](https://www.nuget.org/packages/BinanceDotNet/3.1.0-alpha2)

`Install-Package BinanceDotNet -Version 3.1.0-alpha1 -Prerelease` 
At this point it is critical to include the `-Prerelease` tag

### Confirmations 
- [x] Requests no longer error
- [x] `CreateOrder` can be used without specifying parameters
