### PR TITLE
BDN23 - Added CreateOrder Response types

### DIFF
--- a/BinanceExchange.API/BinanceExchange.API.csproj
+++ b/BinanceExchange.API/BinanceExchange.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451;net452;net461;</TargetFrameworks>
-    <Version>4.0.1</Version>
+    <Version>4.1.0-rc1</Version>
     <Description>The Binance CryptoCurrency exchange C# wrapper of the API. It is built in dotnet core, supports all REST and WebSocket endpoints, has full logging capabilities, a built in Cache for selected endpoints, a Rate limiter and more. Enjoy Binance API data, fast and reliably.</Description>
     <Title>Binance Cryptocurrency Exchange - C# API in .NET</Title>
     <PackageId>BinanceDotNet</PackageId>
@@ -14,9 +14,9 @@
     <PackageLicenseUrl>https://github.com/glitch100/BinanceDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/glitch100/BinanceDotNet</RepositoryUrl>
     <PackageIconUrl>https://i.imgur.com/x2YPVe6.png</PackageIconUrl>
-    <PackageReleaseNotes>Fixed bug around QueryOrder</PackageReleaseNotes>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
-    <FileVersion>4.0.1.0</FileVersion>
+    <PackageReleaseNotes>Added RESULT, ACK, and FULL response types for create order</PackageReleaseNotes>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <FileVersion>4.1.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/BinanceExchange.API/Client/BinanceClient.cs
+++ b/BinanceExchange.API/Client/BinanceClient.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BinanceExchange.API.Caching;
 using BinanceExchange.API.Client.Interfaces;
+using BinanceExchange.API.Enums;
 using BinanceExchange.API.Models.Request;
 using BinanceExchange.API.Models.Response;
+using BinanceExchange.API.Models.Response.Abstract;
 using BinanceExchange.API.Utility;
 using log4net;
 
@@ -206,8 +208,10 @@ namespace BinanceExchange.API.Client
         /// Creates an order based on the provided request
         /// </summary>
         /// <param name="request">The <see cref="CreateOrderRequest"/> that is used to define the order</param>
-        /// <returns></returns>
-        public async Task<CreateOrderResponse> CreateOrder(CreateOrderRequest request)
+        /// <returns>This method can return <see cref="AcknowledgeCreateOrderResponse"/>, <see cref="FullCreateOrderResponse"/> 
+        /// or <see cref="ResultCreateOrderResponse"/> based on the provided NewOrderResponseType enum in the request.
+        /// </returns>
+        public async Task<BaseCreateOrderResponse> CreateOrder(CreateOrderRequest request)
         {
             Guard.AgainstNull(request.Symbol);
             Guard.AgainstNull(request.Side);
@@ -216,7 +220,16 @@ namespace BinanceExchange.API.Client
             Guard.AgainstNull(request.Quantity);
             Guard.AgainstNull(request.Price);
 
-            return await _apiProcessor.ProcessPostRequest<CreateOrderResponse>(Endpoints.Account.NewOrder(request));
+            switch (request.NewOrderResponseType)
+            {
+                case NewOrderResponseType.Acknowledge:
+                    return await _apiProcessor.ProcessPostRequest<AcknowledgeCreateOrderResponse>(Endpoints.Account.NewOrder(request));
+                case NewOrderResponseType.Full:
+                    return await _apiProcessor.ProcessPostRequest<FullCreateOrderResponse>(Endpoints.Account.NewOrder(request));
+                default:
+                    return await _apiProcessor.ProcessPostRequest<ResultCreateOrderResponse>(Endpoints.Account.NewOrder(request));
+            }
+
         }
 
         /// <summary>

--- a/BinanceExchange.API/Client/Interfaces/IBinanceClient.cs
+++ b/BinanceExchange.API/Client/Interfaces/IBinanceClient.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BinanceExchange.API.Models.Request;
 using BinanceExchange.API.Models.Response;
+using BinanceExchange.API.Models.Response.Abstract;
 
 namespace BinanceExchange.API.Client.Interfaces
 {
@@ -85,7 +86,7 @@ namespace BinanceExchange.API.Client.Interfaces
         /// </summary>
         /// <param name="request">The <see cref="CreateOrderRequest"/> that is used to define the order</param>
         /// <returns></returns>
-        Task<CreateOrderResponse> CreateOrder(CreateOrderRequest request);
+        Task<BaseCreateOrderResponse> CreateOrder(CreateOrderRequest request);
 
         /// <summary>
         /// Queries an order based on the provided request

--- a/BinanceExchange.API/Enums/NewOrderResponseType.cs
+++ b/BinanceExchange.API/Enums/NewOrderResponseType.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace BinanceExchange.API.Enums
+{
+    public enum NewOrderResponseType
+    {
+        [EnumMember(Value = "RESULT")]
+        Result,
+        [EnumMember(Value = "ACK")]
+        Acknowledge,
+        [EnumMember(Value = "FULL")]
+        Full,
+    }
+}

--- a/BinanceExchange.API/Models/Request/CreateOrderRequest.cs
+++ b/BinanceExchange.API/Models/Request/CreateOrderRequest.cs
@@ -31,7 +31,7 @@ namespace BinanceExchange.API.Models.Request
         public decimal Quantity { get; set; }
 
         [DataMember(Order = 6)]
-        public double Price { get; set; }
+        public decimal Price { get; set; }
 
         [DataMember(Order = 7)]
         public string NewClientOrderId { get; set; }
@@ -42,5 +42,10 @@ namespace BinanceExchange.API.Models.Request
         [DataMember(Order = 9)]
         [JsonProperty("icebergQty")]
         public decimal? IcebergQuantity { get; set; }
+
+        [DataMember(Order = 10)]
+        [JsonProperty("newOrderRespType")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public NewOrderResponseType NewOrderResponseType { get; set; }
     }
 }

--- a/BinanceExchange.API/Models/Response/Abstract/BaseCreateOrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/Abstract/BaseCreateOrderResponse.cs
@@ -1,16 +1,14 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text;
 using BinanceExchange.API.Converter;
 using BinanceExchange.API.Models.Response.Interfaces;
 using Newtonsoft.Json;
 
-namespace BinanceExchange.API.Models.Response
+namespace BinanceExchange.API.Models.Response.Abstract
 {
-    /// <summary>
-    /// Response following a call to the Create Order endpoint
-    /// </summary>
-    [DataContract]
-    public class CreateOrderResponse : IResponse
+    public abstract class BaseCreateOrderResponse : IResponse
     {
         [DataMember(Order = 1)]
         public string Symbol { get; set; }
@@ -27,5 +25,3 @@ namespace BinanceExchange.API.Models.Response
         public DateTime TransactionTime { get; set; }
     }
 }
-
-    

--- a/BinanceExchange.API/Models/Response/AcknowledgeCreateOrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/AcknowledgeCreateOrderResponse.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+using BinanceExchange.API.Models.Response.Abstract;
+
+namespace BinanceExchange.API.Models.Response
+{
+    /// <summary>
+    /// Acknowledge Response following a call to the Create Order endpoint
+    /// </summary>
+    [DataContract]
+    public class AcknowledgeCreateOrderResponse : BaseCreateOrderResponse
+    {
+    }
+}

--- a/BinanceExchange.API/Models/Response/Fill.cs
+++ b/BinanceExchange.API/Models/Response/Fill.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace BinanceExchange.API.Models.Response
+{
+    [DataContract]
+    public class Fill
+    {
+        [DataMember(Order = 1)]
+        public decimal Price { get; set; }
+
+        [DataMember(Order = 2)]
+        [JsonProperty(PropertyName = "qty")]
+        public int Quantity { get; set; }
+
+        [DataMember(Order = 3)]
+        public decimal Commission { get; set; }
+
+        [DataMember(Order = 5)]
+        public string CommissionAsset { get; set; }
+    }
+}

--- a/BinanceExchange.API/Models/Response/FullCreateOrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/FullCreateOrderResponse.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace BinanceExchange.API.Models.Response
+{
+    /// <summary>
+    /// Full Response following a call to the Create Order endpoint
+    /// </summary>
+    [DataContract]
+    public class FullCreateOrderResponse : ResultCreateOrderResponse
+    {
+        public List<Fill> Fills { get;set; }
+    }
+}
+
+    

--- a/BinanceExchange.API/Models/Response/ResultCreateOrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/ResultCreateOrderResponse.cs
@@ -1,0 +1,43 @@
+using System.Runtime.Serialization;
+using BinanceExchange.API.Enums;
+using BinanceExchange.API.Models.Response.Abstract;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BinanceExchange.API.Models.Response
+{
+    /// <summary>
+    /// Result Response following a call to the Create Order endpoint
+    /// </summary>
+    [DataContract]
+    public partial class ResultCreateOrderResponse : BaseCreateOrderResponse
+    {
+        [DataMember(Order = 4)]
+        public decimal Price { get; set; }
+
+        [DataMember(Order = 5)]
+        [JsonProperty(PropertyName = "origQty")]
+        public decimal OriginalQuantity { get; set; }
+
+        [DataMember(Order = 6)]
+        [JsonProperty(PropertyName = "executedQty")]
+        public decimal ExecutedQuantity { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        [DataMember(Order = 7)]
+        public OrderStatus Status { get; set; }
+
+        [DataMember(Order = 8)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OrderSide Side { get; set; }
+
+        [DataMember(Order = 9)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OrderType Type { get; set; }
+
+        [DataMember(Order = 10)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TimeInForce? TimeInForce { get; set; }
+
+    }
+}

--- a/BinanceExchange.API/Models/Websocket/BinanceTradeOrderData.cs
+++ b/BinanceExchange.API/Models/Websocket/BinanceTradeOrderData.cs
@@ -52,7 +52,7 @@ namespace BinanceExchange.API.Models.WebSocket
 
         [DataMember(Order = 8)]
         [JsonProperty(PropertyName = "p")]
-        public double Price { get; set; }
+        public decimal Price { get; set; }
 
         #region Undefined API Result fields
         //TODO: Update when Binance API updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # BinanceDotNet Changelog
 
+**Release Date: 1/25/2018**
+## 4.1.0
+- Adjusted `CreateOrder` request to allow you to specify what type of response you want
+
 **Release Date: 1/23/2018**
 ## 4.0.1
 - Fixed bug around QueryOrder Http method

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -78,7 +78,7 @@ IBinanceClient.GetSymbolOrderBookTicker()
 ## Account Endpoints
 [Binance Documentation](https://www.binance.com/restapipub.html#user-content-account-endpoints)
 
-### `CreateOrder:CreateOrderResponse`
+### `CreateOrder:BaseCreateOrderResponse`
 Send in a new order.
 ```c#
 IBinanceClient.CreateOrder(CreateOrderRequest request)


### PR DESCRIPTION
## Overview
Added ACK, RESULT, and FULL response types (As determined by provided request) to the `CreateOrder` requests.
Resolves issue #23 

## Installation
https://www.nuget.org/packages/BinanceDotNet/4.1.0-rc1
 
## Testing
- [ ] Can run a `CreateOrder`
- [ ] Can return each of the various response types

