### PR TITLE
Fixed CloseWebSocketInstance, added IsAlive for WebSockets

### DIFF
--- a/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
+++ b/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
@@ -262,24 +262,8 @@ namespace BinanceExchange.API.Websockets
                 ActiveWebSockets.Remove(id);
                 if (!fromError)
                 {
-                    ws.Close(CloseStatusCode.PolicyViolation);
+                    ws.CloseAsync(CloseStatusCode.PolicyViolation);
                 }
-            }
-            else
-            {
-                throw new Exception($"No Websocket exists with the Id {id.ToString()}");
-            }
-        }
-
-        /// <summary>
-        /// Checks whether a specific WebSocket instance is active or not using the Guid provided on creation
-        /// </summary>
-        public bool IsAlive(Guid id)
-        {
-            if (ActiveWebSockets.ContainsKey(id))
-            {
-                var ws = ActiveWebSockets[id];
-                return ws.IsAlive;
             }
             else
             {

--- a/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
+++ b/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
@@ -262,8 +262,24 @@ namespace BinanceExchange.API.Websockets
                 ActiveWebSockets.Remove(id);
                 if (!fromError)
                 {
-                    ws.CloseAsync(CloseStatusCode.PolicyViolation);
+                    ws.Close(CloseStatusCode.PolicyViolation);
                 }
+            }
+            else
+            {
+                throw new Exception($"No Websocket exists with the Id {id.ToString()}");
+            }
+        }
+
+        /// <summary>
+        /// Checks whether a specific WebSocket instance is active or not using the Guid provided on creation
+        /// </summary>
+        public bool IsAlive(Guid id)
+        {
+            if (ActiveWebSockets.ContainsKey(id))
+            {
+                var ws = ActiveWebSockets[id];
+                return ws.IsAlive;
             }
             else
             {


### PR DESCRIPTION
- Fixed CloseWebSocketInstance causing an exception when called.
- Added IsAlive method to check whether a specific WebSocket instance is active or not using the Guid provided on creation

## Overview

## Solved Issues
https://github.com/glitch100/BinanceDotNet/issues/77
https://github.com/glitch100/BinanceDotNet/issues/74

## Installation
N/A

## Acceptance and Testing Steps
[ ] Is it compatible for all target frameworks?

## Other Notes
