### PR TITLE
Handle serialization of ICEBERG_PARTS

### DIFF
--- a/BinanceExchange.API/Converter/ExchangeInfoSymbolFilterConverter.cs
+++ b/BinanceExchange.API/Converter/ExchangeInfoSymbolFilterConverter.cs
@@ -36,6 +36,9 @@ namespace BinanceExchange.API.Converter
                 case ExchangeInfoSymbolFilterType.MaxNumAlgoOrders:
                     item = new ExchangeInfoSymbolFilterMaxNumAlgoOrders();
                     break;
+                case ExchangeInfoSymbolFilterType.IcebergParts:
+                    item = new ExchangeInfoSymbolFilterIcebergParts();
+                    break;
             }
 
             serializer.Populate(jObject.CreateReader(), item);

--- a/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
+++ b/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
@@ -12,5 +12,7 @@ namespace BinanceExchange.API.Enums
         MinNotional,
         [EnumMember(Value = "MAX_NUM_ALGO_ORDERS")]
         MaxNumAlgoOrders,
+        [EnumMember(Value = "ICEBERG_PARTS")]
+        IcebergParts
     }
 }

--- a/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilterIcebergParts.cs
+++ b/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilterIcebergParts.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace BinanceExchange.API.Models.Response
+{
+    [DataContract]
+    public class ExchangeInfoSymbolFilterIcebergParts : ExchangeInfoSymbolFilter
+    {
+        [DataMember(Order = 1 )]
+        public Decimal Limit { get; set; }
+    }
+}

--- a/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilterPrice.cs
+++ b/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilterPrice.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using BinanceExchange.API.Converter;
-using BinanceExchange.API.Models.Response.Interfaces;
 
 namespace BinanceExchange.API.Models.Response
 {


### PR DESCRIPTION
Causes runtime exceptions due to added enum value

## Overview
Binance recently added `ICEBERG_PARTS` to their api and it caused runtime exceptions in existing code due to deserialization errors.

## Solved Issues
Fixes the immediately runtime errors experienced when fetching exchange rules

## Installation
N/A

## Acceptance and Testing Steps
- [x] Is it compatible for all target frameworks?

## Other Notes
No unit tests provided, but this has been manually tested.