### PR TITLE
Remove DataMember Order in ExchangeInfoSymbolFilter

### DIFF
--- a/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilter.cs
+++ b/BinanceExchange.API/Models/Response/ExchangeInfoSymbolFilter.cs
@@ -8,7 +8,6 @@ namespace BinanceExchange.API.Models.Response
     [DataContract]
     public class ExchangeInfoSymbolFilter
     {
-        [DataMember(Order = 1)]
         [JsonConverter(typeof(StringEnumConverter))]
         public ExchangeInfoSymbolFilterType FilterType { get; set; }
     }


### PR DESCRIPTION
## Overview

## Solved Issues
#138 

## Installation
N/A

## Acceptance and Testing Steps
- [x] Is it compatible for all target frameworks?

## Other Notes
I don't think specifying order is neccessary for handling json objects. Json objects should not be assumed to have consistently ordered properties after serialization.