### PR TITLE
Expose TimestampOffset on IBinanceClient interface

### DIFF
--- a/BinanceExchange.API/Client/Interfaces/IBinanceClient.cs
+++ b/BinanceExchange.API/Client/Interfaces/IBinanceClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BinanceExchange.API.Models.Request;
@@ -13,6 +14,11 @@ namespace BinanceExchange.API.Client.Interfaces
         /// </summary>
         /// /// <returns><see cref="UserDataStreamResponse"/></returns>
         Task<UserDataStreamResponse> StartUserDataStream();
+
+        /// <summary>
+        /// Gets or sets the Timestamp offset of the Binance Client
+        /// </summary>
+        TimeSpan TimestampOffset { get; set; }
 
         /// <summary>
         /// Pings a user data stream to prevent timeouts


### PR DESCRIPTION
Noticed that the public TimestampOffset of the BinanceClient class is not available when accessing the class through it's IBinanceClient interface.