### PR TITLE
Fix enum value for ExchangeInfoSymbolFilterType.PercentagePrice

### DIFF
--- a/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
+++ b/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
@@ -33,7 +33,7 @@ namespace BinanceExchange.API.Enums
         [EnumMember(Value = "EXCHANGE_MAX_NUM_ALGO_ORDERS")]
         ExchangeMaxNumAlgoOrders,
         #endregion
-        [EnumMember(Value = "PERCENT_PRICE")]
+        [EnumMember(Value = "PERCENTAGE_PRICE")]
         PercentagePrice,
         [EnumMember(Value = "ICEBERG_PARTS")]
         IcebergParts,


### PR DESCRIPTION
## Overview
Fix enum value for ExchangeInfoSymbolFilterType.PercentagePrice
## Solved Issues
Wrong enum value for ExchangeInfoSymbolFilterType.PercentagePrice

## Installation
N/A

## Acceptance and Testing Steps
- [X] Is it compatible for all target frameworks?

## Other Notes
