### PR TITLE
CummulativeQuoteQuantity is now exposed to the client code.

### DIFF
--- a/BinanceExchange.API/Models/Response/OrderResponse.cs
+++ b/BinanceExchange.API/Models/Response/OrderResponse.cs
@@ -61,5 +61,9 @@ namespace BinanceExchange.API.Models.Response
 
         [DataMember(Order = 14)]
         public bool IsWorking { get; set; }
+
+        [DataMember(Order = 15)]
+        [JsonProperty(PropertyName = "cummulativeQuoteQty")]
+        public decimal CummulativeQuoteQuantity { get; set; }
     }
 }


### PR DESCRIPTION
## Overview
Now we parse and expose the CummulativeQuoteQuantity to the client code.

## Solved Issues
Fill price on a previously filled market order is always zero on OrderResponse for unknown reasons.
But as a workaround we can calculate fill price from the ExecutedQuantity (base coin) and the CummulativeQuoteQuantity (quote coin).

## Installation
N/A

## Acceptance and Testing Steps
- [x] Is it compatible for all target frameworks?
Yes

## Other Notes
N/A