### PR TITLE
Fix for GetExchangeInfo() exception

### DIFF
--- a/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
+++ b/BinanceExchange.API/Enums/ExchangeInfoSymbolFilterType.cs
@@ -33,7 +33,7 @@ namespace BinanceExchange.API.Enums
         [EnumMember(Value = "EXCHANGE_MAX_NUM_ALGO_ORDERS")]
         ExchangeMaxNumAlgoOrders,
         #endregion
-        [EnumMember(Value = "PERCENT_PRICE")]
+        [EnumMember(Value = "PERCENTAGE_PRICE")]
         PercentagePrice,
         [EnumMember(Value = "ICEBERG_PARTS")]
         IcebergParts,


### PR DESCRIPTION
## Overview
There are two (duplicate) PERCENT_PRICE EnumMembers which cause GetExchangeInfo() to throw an exception.
In this fix, second one is renamed to avoid duplication.

## Solved Issues
GetExchangeInfo() exception.

## Installation
N/A

## Acceptance and Testing Steps
- [ ] Is it compatible for all target frameworks?

## Other Notes
N/A