### PR TITLE
Added fast depth stream and GetOrderBook limit was increased to 5000

### DIFF
--- a/BinanceExchange.API/Client/BinanceClient.cs
+++ b/BinanceExchange.API/Client/BinanceClient.cs
@@ -137,9 +137,9 @@ namespace BinanceExchange.API.Client
         public async Task<OrderBookResponse> GetOrderBook(string symbol, bool useCache = false, int limit = 100)
         {
             Guard.AgainstNull(symbol);
-            if (limit > 100)
+            if (limit > 5000)
             {
-                throw new ArgumentException("When requesting the order book, you can't request more than 100 at a time.", nameof(limit));
+                throw new ArgumentException("When requesting the order book, you can't request more than 5000 at a time.", nameof(limit));
             }
             return await _apiProcessor.ProcessGetRequest<OrderBookResponse>(Endpoints.MarketData.OrderBook(symbol, limit, useCache));
         }

--- a/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
+++ b/BinanceExchange.API/Websockets/AbstractBinanceWebSocketClient.cs
@@ -111,6 +111,22 @@ namespace BinanceExchange.API.Websockets
             var endpoint = new Uri($"{BaseWebsocketUri}/{symbol.ToLower()}@depth{(int)levels}");
             return CreateBinanceWebSocket(endpoint, messageEventHandler);
         }
+
+        /// <summary>
+        /// Connect to Partial Book Depth Steam with 100ms frequency
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="levels"></param>
+        /// <param name="messageEventHandler"></param>
+        /// <returns></returns>
+        public Guid ConnectToFastPartialDepthWebSocket(string symbol, PartialDepthLevels levels, BinanceWebSocketMessageHandler<BinancePartialData> messageEventHandler)
+        {
+            Guard.AgainstNullOrEmpty(symbol, nameof(symbol));
+            Logger.Debug("Connecting to Fast Partial Depth Web Socket");
+            var endpoint = new Uri($"{BaseWebsocketUri}/{symbol.ToLower()}@depth{(int)levels}@100ms");
+            return CreateBinanceWebSocket(endpoint, messageEventHandler);
+        }
+
         /// <summary>
         /// Connect to the Combined Depth WebSocket
         /// </summary>


### PR DESCRIPTION
## Overview

-  Added new binance websockets api feature which allow to receive depth update with higher rate (100 ms)
- Changed Book limit up to 5000 according to [docs](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#order-book)

## Solved Issues
N/A

## Installation
N/A

## Acceptance and Testing Steps
- [ ] Is it compatible for all target frameworks?

## Other Notes
